### PR TITLE
Keep showing previously selected state/county when switching between these views

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,11 +117,22 @@
             .then(json => {
               metaStates = json;
               populateStates(metaStates, stateSelStates);
+              // If a state was selected, render it
+              if (stateSelStates.value) {
+                renderState(stateSelStates.value);
+              }
             });
+        } else if (stateSelStates.value) {
+          // If metadata was already loaded and a state is selected, render it
+          renderState(stateSelStates.value);
         }
       } else {
         tabCounties.classList.add('active'); tabStates.classList.remove('active');
         controlsStates.style.display = 'none'; controlsCounties.style.display = '';
+        // If a county was selected, render it
+        if (stateSel.value && countySel.value) {
+          renderCounty(stateSel.value, countySel.value);
+        }
       }
     }
 


### PR DESCRIPTION
Title, basically ;)

Previously, when you had selected a state, then viewed a county, and went back to the state view, the state was still selected, but not shown. Re-selecting the same state didn't work.